### PR TITLE
Implement strategy with /create-spec and how to extend everything (vibe-kanban)

### DIFF
--- a/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
+++ b/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
@@ -1,0 +1,78 @@
+# Spec Requirements Document
+
+> Spec: Kanban Workflow Enhancement
+> Created: 2025-08-26  
+> Status: Planning
+
+## Overview
+
+Enhance Vibe Kanban with batch ticket refinement, environment separation for parallel testing, and multi-agent orchestration with customizable workflows per project. This creates a more sophisticated task management system that leverages specialized agents for development and QA while maintaining simplicity for local development.
+
+## User Stories
+
+### Story 1: Batch Ticket Refinement
+
+As a developer, I want to refine multiple tickets in batches, so that I can efficiently plan and estimate work for entire sprints without context switching between individual tickets.
+
+The workflow involves:
+1. Selecting multiple unrefined tickets from the kanban board
+2. Initiating batch refinement with a planning agent
+3. Agent analyzes related tickets for dependencies and commonalities
+4. Generates consistent estimates and implementation approaches
+5. Updates all tickets with refined details in one operation
+6. Maintains traceability of refinement decisions
+
+### Story 2: Parallel Environment Testing
+
+As a team lead, I want to test multiple feature branches simultaneously in isolated environments, so that QA can proceed in parallel without blocking development.
+
+The experience includes:
+1. Creating isolated worktree environments per task/feature
+2. Running multiple development servers on different ports
+3. QA agent can test each environment independently
+4. Results are aggregated and reported per environment
+5. Environments are automatically cleaned up after testing
+6. Clear visibility of which environments are active
+
+### Story 3: Multi-Agent Workflow Orchestration
+
+As a project manager, I want to customize the kanban workflow with specialized agents for different stages, so that each phase of development gets appropriate expertise and validation.
+
+This enables:
+1. Assigning specific agents to workflow stages (planning, dev, QA, review)
+2. Claude Code CLI integration for agent discovery and loading
+3. Agents can hand off work between stages
+4. Each project can have its own workflow configuration
+5. QA agent independently validates development work
+6. Agents maintain their own context and decision logs
+
+## Spec Scope
+
+1. **Batch Refinement System** - Select and refine multiple tickets simultaneously with AI assistance
+2. **Environment Isolation Manager** - Create and manage parallel testing environments with automatic cleanup
+3. **Agent Registry and Loader** - Discover, load, and manage specialized agents from Claude Code CLI
+4. **Workflow Customization Engine** - Configure per-project workflows with agent assignments
+5. **QA Agent Integration** - Independent quality assurance agent with automated testing capabilities
+
+## Out of Scope
+
+- Production deployment configurations
+- Cloud environment provisioning
+- Agent training or fine-tuning
+- Cross-project agent sharing
+- Real-time collaborative editing
+- CI/CD pipeline integration
+
+## Expected Deliverable
+
+1. Users can select and refine multiple tickets in batch operations with consistent results
+2. Multiple isolated environments run in parallel for independent testing
+3. Projects have customizable workflows with specialized agents for each stage
+4. QA agent independently validates features without blocking development
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/tasks.md
+- Technical Specification: @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/technical-spec.md
+- Database Schema: @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/database-schema.md
+- Tests Specification: @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/tests.md

--- a/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/database-schema.md
+++ b/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/database-schema.md
@@ -1,0 +1,306 @@
+# Database Schema
+
+This is the database schema implementation for the spec detailed in @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
+
+> Created: 2025-08-26
+> Version: 1.0.0
+
+## Schema Changes
+
+### New Tables
+
+#### batch_refinements
+```sql
+CREATE TABLE batch_refinements (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    agent_id TEXT,
+    refinement_prompt TEXT,
+    total_tasks INTEGER NOT NULL,
+    completed_tasks INTEGER DEFAULT 0,
+    error_message TEXT,
+    metadata JSONB,
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'cancelled'))
+);
+
+CREATE INDEX idx_batch_refinements_project ON batch_refinements(project_id);
+CREATE INDEX idx_batch_refinements_status ON batch_refinements(status);
+```
+
+#### batch_refinement_tasks
+```sql
+CREATE TABLE batch_refinement_tasks (
+    batch_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    sequence_order INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    original_state JSONB,
+    refined_state JSONB,
+    changes_applied BOOLEAN DEFAULT FALSE,
+    error_message TEXT,
+    processed_at TIMESTAMP,
+    PRIMARY KEY (batch_id, task_id),
+    FOREIGN KEY (batch_id) REFERENCES batch_refinements(id) ON DELETE CASCADE,
+    FOREIGN KEY (task_id) REFERENCES tasks(id),
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'skipped'))
+);
+
+CREATE INDEX idx_batch_tasks_status ON batch_refinement_tasks(status);
+```
+
+#### environments
+```sql
+CREATE TABLE environments (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    task_id TEXT,
+    worktree_path TEXT NOT NULL UNIQUE,
+    branch TEXT NOT NULL,
+    port INTEGER,
+    status TEXT NOT NULL DEFAULT 'initializing',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_accessed TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    cleanup_after TIMESTAMP,
+    metadata JSONB,
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    FOREIGN KEY (task_id) REFERENCES tasks(id),
+    CHECK (status IN ('initializing', 'running', 'testing', 'idle', 'cleaning', 'terminated'))
+);
+
+CREATE INDEX idx_environments_project ON environments(project_id);
+CREATE INDEX idx_environments_status ON environments(status);
+CREATE INDEX idx_environments_cleanup ON environments(cleanup_after);
+```
+
+#### workflow_configurations
+```sql
+CREATE TABLE workflow_configurations (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    configuration JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT NOT NULL,
+    is_active BOOLEAN DEFAULT TRUE,
+    FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+CREATE INDEX idx_workflow_project ON workflow_configurations(project_id);
+```
+
+#### workflow_stages
+```sql
+CREATE TABLE workflow_stages (
+    id TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    sequence_order INTEGER NOT NULL,
+    agent_id TEXT,
+    auto_transition BOOLEAN DEFAULT FALSE,
+    is_parallel BOOLEAN DEFAULT FALSE,
+    is_required BOOLEAN DEFAULT TRUE,
+    manual_trigger BOOLEAN DEFAULT FALSE,
+    configuration JSONB,
+    FOREIGN KEY (workflow_id) REFERENCES workflow_configurations(id) ON DELETE CASCADE,
+    UNIQUE (workflow_id, name),
+    UNIQUE (workflow_id, sequence_order)
+);
+
+CREATE INDEX idx_stages_workflow ON workflow_stages(workflow_id);
+```
+
+#### agents
+```sql
+CREATE TABLE agents (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    version TEXT,
+    capabilities JSONB,
+    configuration JSONB,
+    is_active BOOLEAN DEFAULT TRUE,
+    last_used TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CHECK (type IN ('planning', 'development', 'qa', 'review', 'custom'))
+);
+
+CREATE INDEX idx_agents_type ON agents(type);
+CREATE INDEX idx_agents_active ON agents(is_active);
+```
+
+#### agent_executions
+```sql
+CREATE TABLE agent_executions (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    task_id TEXT,
+    batch_id TEXT,
+    environment_id TEXT,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP,
+    status TEXT NOT NULL DEFAULT 'running',
+    input_context JSONB,
+    output_context JSONB,
+    error_message TEXT,
+    execution_time_ms INTEGER,
+    FOREIGN KEY (agent_id) REFERENCES agents(id),
+    FOREIGN KEY (task_id) REFERENCES tasks(id),
+    FOREIGN KEY (batch_id) REFERENCES batch_refinements(id),
+    FOREIGN KEY (environment_id) REFERENCES environments(id),
+    CHECK (status IN ('running', 'completed', 'failed', 'cancelled'))
+);
+
+CREATE INDEX idx_executions_agent ON agent_executions(agent_id);
+CREATE INDEX idx_executions_task ON agent_executions(task_id);
+CREATE INDEX idx_executions_status ON agent_executions(status);
+```
+
+### Modified Tables
+
+#### tasks (modifications)
+```sql
+ALTER TABLE tasks 
+ADD COLUMN workflow_stage TEXT,
+ADD COLUMN assigned_agent_id TEXT,
+ADD COLUMN refinement_data JSONB,
+ADD COLUMN environment_id TEXT,
+ADD FOREIGN KEY (assigned_agent_id) REFERENCES agents(id),
+ADD FOREIGN KEY (environment_id) REFERENCES environments(id);
+
+CREATE INDEX idx_tasks_workflow_stage ON tasks(workflow_stage);
+CREATE INDEX idx_tasks_environment ON tasks(environment_id);
+```
+
+#### projects (modifications)
+```sql
+ALTER TABLE projects
+ADD COLUMN workflow_enabled BOOLEAN DEFAULT FALSE,
+ADD COLUMN default_agents JSONB,
+ADD COLUMN environment_settings JSONB;
+```
+
+## Migration Scripts
+
+### Up Migration
+```sql
+-- Migration: 0001_kanban_workflow_enhancement.up.sql
+
+-- Create batch refinement tables
+CREATE TABLE batch_refinements (...);
+CREATE TABLE batch_refinement_tasks (...);
+
+-- Create environment management tables
+CREATE TABLE environments (...);
+
+-- Create workflow configuration tables
+CREATE TABLE workflow_configurations (...);
+CREATE TABLE workflow_stages (...);
+
+-- Create agent management tables
+CREATE TABLE agents (...);
+CREATE TABLE agent_executions (...);
+
+-- Modify existing tables
+ALTER TABLE tasks ...;
+ALTER TABLE projects ...;
+
+-- Create all indexes
+CREATE INDEX ...;
+
+-- Insert default agents
+INSERT INTO agents (id, name, type, capabilities) VALUES
+  ('claude-planning', 'Claude Planning Agent', 'planning', '{"refinement": true, "estimation": true}'),
+  ('claude-code', 'Claude Code Agent', 'development', '{"coding": true, "testing": true}'),
+  ('qa-specialist', 'QA Specialist Agent', 'qa', '{"testing": true, "validation": true}'),
+  ('tech-lead', 'Tech Lead Review Agent', 'review', '{"code_review": true, "architecture": true}');
+```
+
+### Down Migration
+```sql
+-- Migration: 0001_kanban_workflow_enhancement.down.sql
+
+-- Remove added columns from existing tables
+ALTER TABLE tasks 
+DROP COLUMN workflow_stage,
+DROP COLUMN assigned_agent_id,
+DROP COLUMN refinement_data,
+DROP COLUMN environment_id;
+
+ALTER TABLE projects
+DROP COLUMN workflow_enabled,
+DROP COLUMN default_agents,
+DROP COLUMN environment_settings;
+
+-- Drop all new tables
+DROP TABLE agent_executions;
+DROP TABLE agents;
+DROP TABLE workflow_stages;
+DROP TABLE workflow_configurations;
+DROP TABLE environments;
+DROP TABLE batch_refinement_tasks;
+DROP TABLE batch_refinements;
+```
+
+## Query Patterns
+
+### Get Active Environments
+```sql
+SELECT e.*, t.name as task_name, p.name as project_name
+FROM environments e
+JOIN projects p ON e.project_id = p.id
+LEFT JOIN tasks t ON e.task_id = t.id
+WHERE e.status IN ('running', 'testing', 'idle')
+ORDER BY e.created_at DESC;
+```
+
+### Get Batch Refinement Progress
+```sql
+SELECT 
+    br.*,
+    COUNT(brt.task_id) as total_tasks,
+    SUM(CASE WHEN brt.status = 'completed' THEN 1 ELSE 0 END) as completed_tasks
+FROM batch_refinements br
+LEFT JOIN batch_refinement_tasks brt ON br.id = brt.batch_id
+WHERE br.id = ?
+GROUP BY br.id;
+```
+
+### Get Workflow Configuration
+```sql
+SELECT 
+    wc.*,
+    json_agg(
+        json_build_object(
+            'stage', ws.name,
+            'order', ws.sequence_order,
+            'agent', a.name,
+            'capabilities', a.capabilities
+        ) ORDER BY ws.sequence_order
+    ) as stages
+FROM workflow_configurations wc
+JOIN workflow_stages ws ON wc.id = ws.workflow_id
+LEFT JOIN agents a ON ws.agent_id = a.id
+WHERE wc.project_id = ? AND wc.is_active = true
+GROUP BY wc.id;
+```
+
+## Performance Optimizations
+
+1. **Partitioning**: Consider partitioning agent_executions by created_at for better query performance
+2. **Indexes**: All foreign keys and commonly queried columns have indexes
+3. **JSONB**: Using JSONB for flexible schema while maintaining query performance
+4. **Cleanup**: Automated cleanup of old environment and execution records via scheduled jobs
+
+## Data Integrity
+
+1. **Foreign Keys**: All relationships properly constrained
+2. **Check Constraints**: Status fields limited to valid values
+3. **Unique Constraints**: Prevent duplicate workflow stages and configurations
+4. **Cascading Deletes**: Proper cleanup of related records
+5. **Transactions**: Batch operations wrapped in transactions for consistency

--- a/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/technical-spec.md
@@ -1,0 +1,205 @@
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
+
+> Created: 2025-08-26
+> Version: 1.0.0
+
+## Technical Requirements
+
+### Batch Refinement System
+- Multi-select UI component for ticket selection in kanban board
+- Batch processing endpoint that handles multiple ticket IDs
+- Agent context aggregation for related tickets
+- Atomic updates to ensure consistency across batch operations
+- Rollback mechanism for failed batch refinements
+- Progress tracking and status updates via SSE
+
+### Environment Isolation
+- Extend WorktreeManager to support multiple active worktrees
+- Dynamic port allocation for parallel dev servers (3001, 3002, etc.)
+- Environment registry tracking active instances
+- Resource cleanup scheduler for orphaned environments
+- Environment status monitoring (running, testing, idle)
+- Integration with existing git worktree management
+
+### Agent Management
+- Agent discovery via Claude Code CLI commands
+- Dynamic agent loading based on configuration
+- Agent capability registration and discovery
+- Inter-agent communication protocol
+- Agent state persistence between sessions
+- Support for custom agent prompts and instructions
+
+### Workflow Engine
+- YAML/JSON-based workflow configuration per project
+- State machine for workflow transitions
+- Agent-to-stage mapping configuration
+- Workflow validation and error handling
+- Event-driven stage transitions
+- Audit trail for workflow executions
+
+### QA Integration
+- Independent QA agent with testing capabilities
+- Integration with MCP browser automation tools
+- Test result aggregation and reporting
+- Automatic issue creation from test failures
+- Parallel test execution across environments
+- Test coverage tracking and metrics
+
+## Approach Options
+
+### Option A: Monolithic Enhancement
+- Pros: Simpler implementation, fewer moving parts, easier debugging
+- Cons: Less flexible, harder to scale, tight coupling
+
+### Option B: Microservice Architecture
+- Pros: Better separation of concerns, scalable, independent deployment
+- Cons: Complex orchestration, overhead for local development
+
+### Option C: Plugin-Based System (Selected)
+- Pros: Modular, extensible, maintains simplicity for local dev, easy to test
+- Cons: Requires well-defined interfaces, plugin discovery overhead
+
+**Rationale:** Plugin-based approach provides the best balance between flexibility and simplicity for local development while allowing future extensibility.
+
+## System Architecture
+
+### Component Design
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Frontend (React)                       │
+├─────────────────────────────────────────────────────────┤
+│  BatchRefinement │ EnvironmentView │ WorkflowConfig     │
+│    Component     │    Component    │    Component       │
+└─────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│                   API Layer (Axum)                       │
+├─────────────────────────────────────────────────────────┤
+│  /api/batch/*    │  /api/envs/*    │  /api/workflow/*   │
+└─────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│                   Service Layer                          │
+├──────────────┬──────────────┬──────────────┬───────────┤
+│   Batch      │ Environment  │   Workflow   │   Agent   │
+│   Service    │   Manager    │    Engine    │  Registry │
+└──────────────┴──────────────┴──────────────┴───────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│                     Database (SQLite)                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Agent Communication Flow
+
+```
+User → Task Creation → Planning Agent → Development Agent → QA Agent → Review
+         ↓                ↓                  ↓                ↓
+    Task Record      Refinement          Implementation    Test Results
+```
+
+## Implementation Details
+
+### Batch Refinement API
+```rust
+// POST /api/batch/refine
+pub struct BatchRefineRequest {
+    task_ids: Vec<String>,
+    refinement_prompt: Option<String>,
+    agent_id: Option<String>,
+}
+
+// Response includes progress updates via SSE
+pub struct BatchRefineProgress {
+    total: usize,
+    completed: usize,
+    current_task: String,
+    status: BatchStatus,
+}
+```
+
+### Environment Registry
+```rust
+pub struct Environment {
+    id: String,
+    worktree_path: String,
+    branch: String,
+    port: u16,
+    status: EnvironmentStatus,
+    created_at: DateTime<Utc>,
+    last_accessed: DateTime<Utc>,
+}
+
+pub struct EnvironmentManager {
+    environments: HashMap<String, Environment>,
+    port_allocator: PortAllocator,
+    cleanup_scheduler: CleanupScheduler,
+}
+```
+
+### Workflow Configuration
+```yaml
+# .vibe/workflow.yml
+name: "Custom Development Workflow"
+stages:
+  - name: refinement
+    agent: claude-planning-agent
+    auto_transition: true
+  - name: development
+    agent: claude-code-agent
+    parallel: true
+  - name: qa
+    agent: qa-specialist-agent
+    required: true
+  - name: review
+    agent: tech-lead-agent
+    manual_trigger: true
+```
+
+### Agent Interface
+```rust
+#[async_trait]
+pub trait Agent {
+    async fn initialize(&mut self, config: AgentConfig) -> Result<()>;
+    async fn execute(&self, task: Task, context: AgentContext) -> Result<AgentOutput>;
+    asyncផget_capabilities(&self) -> Vec<Capability>;
+    async fn handoff(&self, next_agent: &str, context: HandoffContext) -> Result<()>;
+}
+```
+
+## External Dependencies
+
+- **ts-rs** - Already in use for TypeScript type generation
+- **tokio** - Already in use for async runtime
+- **serde_yaml** - For workflow configuration parsing
+- **Justification:** Minimal and necessary for YAML config support
+
+## Performance Considerations
+
+- Batch operations use database transactions for atomicity
+- Environment cleanup runs on background thread
+- Agent communication uses async message passing
+- SSE for real-time updates without polling
+- Lazy loading of agent configurations
+
+## Security Considerations  
+
+- Agent permissions scoped per project
+- Environment isolation prevents cross-contamination
+- Audit logging for all agent actions
+- Sanitization of agent prompts and outputs
+- Rate limiting on batch operations
+
+## Migration Strategy
+
+1. Existing single-task workflow remains default
+2. Batch refinement opt-in via feature flag
+3. Environment isolation gradual rollout
+4. Agent system backwards compatible with current executors
+5. Data migration for workflow configurations

--- a/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/tests.md
+++ b/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/sub-specs/tests.md
@@ -1,0 +1,211 @@
+# Tests Specification
+
+This is the tests coverage details for the spec detailed in @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
+
+> Created: 2025-08-26
+> Version: 1.0.0
+
+## Test Coverage
+
+### Unit Tests
+
+**BatchRefinementService**
+- Test batch creation with valid task IDs
+- Test batch creation with invalid/missing task IDs  
+- Test atomic transaction rollback on failure
+- Test progress tracking updates via SSE
+- Test concurrent batch operations handling
+- Test batch cancellation mid-process
+
+**EnvironmentManager**
+- Test environment creation with unique ports
+- Test parallel environment initialization
+- Test cleanup scheduler for idle environments
+- Test port allocation and deallocation
+- Test environment status transitions
+- Test orphaned environment detection
+
+**WorkflowEngine**
+- Test workflow configuration loading from YAML
+- Test stage transition logic with auto-transition
+- Test parallel stage execution
+- Test manual trigger requirements
+- Test workflow validation and error handling
+- Test workflow state persistence
+
+**AgentRegistry**
+- Test agent discovery via CLI commands
+- Test agent capability registration
+- Test agent loading and initialization
+- Test agent version compatibility checks
+- Test fallback to default agents
+- Test custom agent validation
+
+**PortAllocator**
+- Test sequential port allocation
+- Test port recycling after environment cleanup
+- Test port conflict resolution
+- Test maximum port limit handling
+
+### Integration Tests
+
+**Batch Refinement Flow**
+- Test end-to-end batch refinement with 10 tickets
+- Test partial batch failure recovery
+- Test batch refinement with custom agent
+- Test concurrent batches for different projects
+- Test batch status updates via SSE stream
+- Test batch results persistence
+
+**Multi-Environment Testing**
+- Test spinning up 3 parallel environments
+- Test independent testing in each environment
+- Test environment isolation (no cross-contamination)
+- Test automatic cleanup after idle timeout
+- Test resource limits and throttling
+
+**Agent Orchestration**
+- Test complete workflow: planning → development → QA → review
+- Test agent handoff with context preservation
+- Test parallel agent execution
+- Test agent failure and retry logic
+- Test custom agent integration
+- Test agent execution audit trail
+
+**Workflow Customization**
+- Test loading project-specific workflow
+- Test workflow validation on configuration change
+- Test stage skipping based on conditions
+- Test workflow rollback on critical failure
+
+### E2E Tests
+
+**Batch Refinement User Flow**
+- User selects 5 unrefined tickets
+- Initiates batch refinement
+- Monitors progress in real-time
+- Reviews refined tickets
+- Applies or rejects changes
+- Verifies database consistency
+
+**Parallel Environment Workflow**
+- Create task requiring environment
+- Spawn development environment
+- Start QA testing in parallel environment
+- Monitor both environments simultaneously
+- Clean up after testing completion
+- Verify no resource leaks
+
+**Multi-Agent Development Cycle**
+- Create new task
+- Planning agent refines requirements
+- Development agent implements feature
+- QA agent runs automated tests
+- Review agent provides feedback
+- Task moves through workflow stages
+- Verify complete audit trail
+
+### Mocking Requirements
+
+**External Services**
+- **GitHub API:** Mock PR creation, status updates
+- **Claude Code CLI:** Mock agent discovery responses
+- **MCP Browser Tools:** Mock for QA testing simulation
+- **File System:** Mock for worktree operations in tests
+
+**Time-Based Tests**
+- **Environment Idle Timeout:** Mock time progression
+- **Cleanup Scheduler:** Mock scheduled job execution
+- **Rate Limiting:** Mock time-based request throttling
+
+**Agent Communication**
+- **Agent Responses:** Mock LLM responses for deterministic testing
+- **Agent Capabilities:** Mock capability discovery
+- **Inter-Agent Messages:** Mock message passing between agents
+
+## Test Data
+
+### Fixtures
+
+```rust
+// Test fixture for batch refinement
+pub fn create_test_batch() -> BatchRefinement {
+    BatchRefinement {
+        id: "test-batch-001".to_string(),
+        project_id: "test-project".to_string(),
+        task_ids: vec!["task-1", "task-2", "task-3"],
+        status: BatchStatus::Pending,
+        // ...
+    }
+}
+
+// Test fixture for environment
+pub fn create_test_environment() -> Environment {
+    Environment {
+        id: "test-env-001".to_string(),
+        worktree_path: "/tmp/test-worktree",
+        port: 3001,
+        status: EnvironmentStatus::Running,
+        // ...
+    }
+}
+
+// Test fixture for workflow
+pub fn create_test_workflow() -> WorkflowConfiguration {
+    WorkflowConfiguration {
+        id: "test-workflow-001".to_string(),
+        stages: vec![
+            WorkflowStage { name: "planning", agent_id: Some("claude-planning") },
+            WorkflowStage { name: "development", agent_id: Some("claude-code") },
+            WorkflowStage { name: "qa", agent_id: Some("qa-specialist") },
+        ],
+        // ...
+    }
+}
+```
+
+## Performance Tests
+
+### Load Testing
+- Batch refinement with 100 tickets
+- 10 parallel environments running simultaneously
+- 50 concurrent agent executions
+- Workflow processing under high load
+
+### Stress Testing
+- Maximum batch size limits
+- Port exhaustion scenarios
+- Agent timeout handling
+- Database connection pool limits
+
+## Test Execution Strategy
+
+### CI/CD Pipeline
+```yaml
+test:
+  - cargo test --workspace           # All unit tests
+  - cargo test --test integration    # Integration tests
+  - npm run test:e2e                # E2E tests with Playwright
+  - cargo test --release -- --ignored # Performance tests
+```
+
+### Test Categories
+- **Fast Tests:** Run on every commit (< 1 second each)
+- **Integration Tests:** Run on PR creation (< 10 seconds each)
+- **E2E Tests:** Run before merge (< 30 seconds each)
+- **Performance Tests:** Run nightly or on-demand
+
+## Test Coverage Requirements
+
+- Unit test coverage: > 80%
+- Integration test coverage: > 70%
+- Critical paths: 100% coverage
+- New code: 90% coverage minimum
+
+## Test Documentation
+
+Each test should include:
+1. Clear test name describing what is being tested
+2. Given-When-Then structure for complex scenarios
+3. Assertion messages explaining expected behavior
+4. Cleanup verification for resource management tests

--- a/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/tasks.md
+++ b/.agent-os/specs/2025-08-26-kanban-workflow-enhancement/tasks.md
@@ -1,0 +1,63 @@
+# Spec Tasks
+
+These are the tasks to be completed for the spec detailed in @.agent-os/specs/2025-08-26-kanban-workflow-enhancement/spec.md
+
+> Created: 2025-08-26
+> Status: Ready for Implementation
+
+## Tasks
+
+- [ ] 1. Implement Batch Refinement System
+  - [ ] 1.1 Write tests for BatchRefinementService
+  - [ ] 1.2 Create database migrations for batch refinement tables
+  - [ ] 1.3 Implement BatchRefinementService in Rust
+  - [ ] 1.4 Add batch refinement API endpoints
+  - [ ] 1.5 Create BatchRefinementComponent in React
+  - [ ] 1.6 Implement multi-select UI for ticket selection
+  - [ ] 1.7 Add SSE progress tracking for batch operations
+  - [ ] 1.8 Verify batch refinement works using MCP browser tools
+  - [ ] 1.9 Verify all tests pass
+
+- [ ] 2. Build Environment Isolation Manager
+  - [ ] 2.1 Write tests for EnvironmentManager
+  - [ ] 2.2 Create database tables for environments
+  - [ ] 2.3 Extend WorktreeManager for multiple worktrees
+  - [ ] 2.4 Implement PortAllocator for dynamic port assignment
+  - [ ] 2.5 Create environment lifecycle management service
+  - [ ] 2.6 Add cleanup scheduler for orphaned environments
+  - [ ] 2.7 Build EnvironmentView component for monitoring
+  - [ ] 2.8 Run E2E test to verify parallel environments work
+  - [ ] 2.9 Verify all tests pass
+
+- [ ] 3. Create Agent Registry and Loader
+  - [ ] 3.1 Write tests for AgentRegistry
+  - [ ] 3.2 Create agents and agent_executions tables
+  - [ ] 3.3 Implement agent discovery via Claude Code CLI
+  - [ ] 3.4 Build AgentRegistry service with capability mapping
+  - [ ] 3.5 Create agent loading and initialization logic
+  - [ ] 3.6 Implement inter-agent communication protocol
+  - [ ] 3.7 Add agent management UI components
+  - [ ] 3.8 Verify agent loading works using MCP browser tools
+  - [ ] 3.9 Verify all tests pass
+
+- [ ] 4. Develop Workflow Customization Engine
+  - [ ] 4.1 Write tests for WorkflowEngine
+  - [ ] 4.2 Create workflow configuration tables
+  - [ ] 4.3 Implement YAML workflow configuration parser
+  - [ ] 4.4 Build WorkflowEngine with state machine logic
+  - [ ] 4.5 Create workflow API endpoints
+  - [ ] 4.6 Develop WorkflowConfig UI component
+  - [ ] 4.7 Implement workflow validation and error handling
+  - [ ] 4.8 Verify workflow customization using MCP browser tools
+  - [ ] 4.9 Verify all tests pass
+
+- [ ] 5. Integrate QA Agent System
+  - [ ] 5.1 Write integration tests for QA agent
+  - [ ] 5.2 Configure QA specialist agent with MCP browser tools
+  - [ ] 5.3 Implement automated test execution logic
+  - [ ] 5.4 Create test result aggregation service
+  - [ ] 5.5 Build QA dashboard components
+  - [ ] 5.6 Integrate with existing task validation flow
+  - [ ] 5.7 Add automatic issue creation from test failures
+  - [ ] 5.8 Run full E2E test of QA agent validating a feature
+  - [ ] 5.9 Verify all integration tests pass


### PR DESCRIPTION
/create-spec look at the docs with some proposals - review existing implementation and create a proposal on how we could enhtheance kanban. Our concentration is to first refine tickets in batches - how to seperate envirments so we can test them same time and as well how to improve QA 
the idea to ability to customise kanban workflow per project but as well use diffrent agents so for example we should have one main agent to create development but another independthient to qa everything we should integrate everything with claude code cli commands and sub agents so we should be able to recognise them load and modify if need it. 
Try to find a simple solutions not to overenginer look this as lead architect but skip production parts we doing this first for local